### PR TITLE
chore: enable npm trusted publishing via OIDC provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -46,11 +46,12 @@ jobs:
           version: 9
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm run dist
       - run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/doc.workflow.yml
+++ b/.github/workflows/doc.workflow.yml
@@ -17,7 +17,7 @@ jobs:
           version: 9
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm run dist


### PR DESCRIPTION
- Configure release job to use GitHub Actions OIDC for npm authentication instead of NPM_TOKEN secret (which now requires 2FA)
- Add registry-url to actions/setup-node for OIDC token exchange
- Set NPM_CONFIG_PROVENANCE=true for signed publish attestations
- Remove NPM_TOKEN from release job env
- Add Node 24 to test matrix and bump release/docs workflows to Node 24

https://claude.ai/code/session_01B5RqRax3cCEUgMkwf2Zym2